### PR TITLE
Hack x' \subseteq S implementation

### DIFF
--- a/tlatools/org.lamport.tlatools/test-model/SubseteqNextState.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/SubseteqNextState.cfg
@@ -1,0 +1,3 @@
+INIT Init
+NEXT Next
+INVARIANTS TypeOK Inv

--- a/tlatools/org.lamport.tlatools/test-model/SubseteqNextState.tla
+++ b/tlatools/org.lamport.tlatools/test-model/SubseteqNextState.tla
@@ -1,0 +1,7 @@
+---- MODULE SubseteqNextState ----
+VARIABLE x
+TypeOK == x \subseteq {1, 2, 3}
+Inv == ENABLED (x' \subseteq {1})
+Init == x \subseteq {1, 2}
+Next == x' \subseteq {1, 2, 3}
+====

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/SubseteqNextStateTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/SubseteqNextStateTest.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Linux Foundation. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+/**
+ * Tests evaluation of expressions of the form x' \subseteq S
+ */
+public class SubseteqNextStateTest extends ModelCheckerTestCase {
+
+	public SubseteqNextStateTest() {
+	  super("SubseteqNextState");
+	}
+	
+	@Test
+	public void testSpec() throws IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertFalse(recorder.recorded(EC.GENERAL));
+
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "68", "8", "0"));
+		assertTrue(recorder.recordedWithStringValue(EC.TLC_SEARCH_DEPTH, "2"));
+	}
+}


### PR DESCRIPTION
Combined the logic in `OPCODE_subset` and `OPCODE_in` to implement support for `x' \subseteq S` expressions in TLC. Every given operator needs to be implemented in four places in the `Tool` class:
1. `getInitStatesAppl` - define operator for initial state
1. `getNextStatesApplSwitch` - define operator for next-state generation
1. `evalApplImpl` - define operator for basic evaluation within a state
1. `enabledApplImpl` - define operator for calculation of ENABLED

Possibly there are other implementations of the `Tool` class (like in the debugger?) where this functionality needs to be duplicated.

Given that `OPCODE_subset` is the opcode for the `SUBSET` prefix operator and `OPCODE_subseteq` is the opcode for the `\subseteq` infix operator, I'm not sure what would be the opcode for the `\subset` infix operator but whatever (edit: turns out `\subset` is not part of the TLA+ built-ins so is reserved as a user-definable operator, and thus does not have an opcode).

You can download this zip and rename it to a jar to try out this build: [tla2tools.zip](https://github.com/user-attachments/files/24404674/tla2tools.zip)
